### PR TITLE
accept JSON Type was changed in some methods of  ConfigServiceAdminCl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <service.name>ConfigService</service.name>
 
         <!-- internal dependencies -->
-        <configservice-sdk.version>0.19.3</configservice-sdk.version>        
+        <configservice-sdk.version>0.19.5-SNAPSHOT</configservice-sdk.version>
 
         <!-- app deps -->
         <jersey.version>2.35</jersey.version>

--- a/src/test/java/no/cantara/cs/admin/ApplicationResourceTest.java
+++ b/src/test/java/no/cantara/cs/admin/ApplicationResourceTest.java
@@ -44,7 +44,7 @@ public class ApplicationResourceTest extends BaseSystemTest {
                 .body(mapper.writeValueAsString(application1))
                 .log().everything()
                 .expect()
-                .statusCode(HttpURLConnection.HTTP_BAD_REQUEST)
+                .statusCode(HttpURLConnection.HTTP_FORBIDDEN)
                 .log().everything()
                 .when()
                 .post(ApplicationResource.APPLICATION_PATH);


### PR DESCRIPTION
Some methods of ConfigServiceAdminClient in [ConfigService-SDK](https://github.com/Cantara/ConfigService-SDK)  were changed to accept MediaType.JSON, for example:

`    public ApplicationConfig createApplicationConfig(Application application, ApplicationConfig config) throws IOException {
        Response response = applicationResource.path(application.id + "/config/").request().accept(new MediaType[]{MediaType.APPLICATION_JSON_TYPE}).post(jsonEntity(config));
        return readValue(response, ApplicationConfig.class);
    }`